### PR TITLE
feat: Adiciona página de teste de velocidade de internet

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,46 @@
                 </div>
             </section>
             
+            <section id="speed-test-section" class="space-y-4 mb-8">
+                <div>
+                    <button id="toggle-speed-test" class="w-full bg-sky-500 hover:bg-sky-600 text-white font-semibold py-3 px-4 rounded-lg shadow transition-colors duration-150 flex justify-between items-center">
+                        <span>⚡ Teste de Velocidade da Internet</span>
+                        <span class="transform transition-transform duration-300" id="speed-test-arrow">▼</span>
+                    </button>
+                    <div id="speed-test-content" class="content-section mt-2 p-4 bg-slate-100 rounded-lg shadow-inner">
+                        <div class="p-2 rounded bg-white shadow">
+                            <p class="text-stone-700 mb-4">
+                                Verifique a velocidade da sua conexão. Insira a velocidade contratada (em Mbps) para calcular a porcentagem alcançada.
+                            </p>
+
+                            <div class="mb-4">
+                                <label for="contracted-speed" class="block text-sm font-medium text-stone-700 mb-1">Velocidade Contratada (Mbps):</label>
+                                <input type="number" id="contracted-speed" name="contracted-speed" class="mt-1 block w-full px-3 py-2 bg-white border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm" placeholder="Ex: 100">
+                            </div>
+
+                            <button id="start-speed-test-button" class="w-full bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-lg shadow transition-colors duration-150 mb-4">
+                                Iniciar Teste
+                            </button>
+
+                            <div id="speed-test-results" class="mt-4 space-y-2">
+                                <p class="text-stone-700"><strong>Resultados:</strong></p>
+                                <div class="grid grid-cols-2 gap-2 text-sm">
+                                    <p>Ping: <span id="ping-value">-</span> ms</p>
+                                    <p>Jitter: <span id="jitter-value">-</span> ms</p>
+                                    <p>Download: <span id="download-value">-</span> Mbps</p>
+                                    <p>Upload: <span id="upload-value">-</span> Mbps</p>
+                                </div>
+                                <p id="progress-message" class="text-sm text-sky-600"></p>
+                                <div id="percentage-result-area" class="mt-3 pt-3 border-t border-stone-200">
+                                    <p class="font-semibold text-stone-700">Desempenho da Velocidade Contratada (Download):</p>
+                                    <p id="percentage-value" class="text-lg font-bold text-sky-700">- %</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <div class="text-center mt-8">
                  <button id="restart-button" class="bg-amber-500 hover:bg-amber-600 text-white font-semibold py-3 px-6 rounded-lg shadow transition-colors duration-150">
                     🔄 Reiniciar Diagnóstico
@@ -108,6 +148,7 @@
     </div>
 
     <script src="js/diagnostic-data.js"></script>
+    <script src="lib/librespeed/speedtest.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,19 @@ const toolsButton = document.getElementById('toggle-tools');
 const toolsContent = document.getElementById('tools-content');
 const toolsArrow = document.getElementById('tools-arrow');
 
+const speedTestSectionButton = document.getElementById('toggle-speed-test');
+const speedTestContent = document.getElementById('speed-test-content');
+const speedTestArrow = document.getElementById('speed-test-arrow');
+const contractedSpeedInput = document.getElementById('contracted-speed');
+const startSpeedTestButton = document.getElementById('start-speed-test-button');
+const pingValue = document.getElementById('ping-value');
+const jitterValue = document.getElementById('jitter-value');
+const downloadValue = document.getElementById('download-value');
+const uploadValue = document.getElementById('upload-value');
+const progressMessage = document.getElementById('progress-message');
+const percentageValue = document.getElementById('percentage-value');
+const percentageResultArea = document.getElementById('percentage-result-area');
+
 /**
  * Renders a diagnostic step based on its ID
  * @param {string} stepId - The ID of the step to render
@@ -78,28 +91,38 @@ function renderStep(stepId) {
  */
 function toggleSection(contentElement, arrowElement) {
     const isOpen = contentElement.classList.contains('open');
-    
+
+    // Define all collapsible sections and their controls
+    const sections = [
+        { id: 'concepts-content', content: conceptsContent, arrow: conceptsArrow, button: conceptsButton },
+        { id: 'tools-content', content: toolsContent, arrow: toolsArrow, button: toolsButton },
+        { id: 'speed-test-content', content: speedTestContent, arrow: speedTestArrow, button: speedTestSectionButton }
+    ];
+
     if (isOpen) {
+        // If the clicked section is already open, just close it
         contentElement.classList.remove('open');
-        arrowElement.classList.remove('rotate-180');
+        if (arrowElement) arrowElement.classList.remove('rotate-180');
     } else {
-        // Close other section if open
-        if (contentElement.id === 'concepts-content' && toolsContent.classList.contains('open')) {
-            toolsContent.classList.remove('open');
-            toolsArrow.classList.remove('rotate-180');
-        } else if (contentElement.id === 'tools-content' && conceptsContent.classList.contains('open')) {
-            conceptsContent.classList.remove('open');
-            conceptsArrow.classList.remove('rotate-180');
-        }
-        
-        contentElement.classList.add('open');
-        arrowElement.classList.add('rotate-180');
+        // If the clicked section is closed, close all others and open the clicked one
+        sections.forEach(section => {
+            if (section.content && section.arrow) { // Ensure elements exist
+                if (section.content === contentElement) {
+                    section.content.classList.add('open');
+                    section.arrow.classList.add('rotate-180');
+                } else {
+                    section.content.classList.remove('open');
+                    section.arrow.classList.remove('rotate-180');
+                }
+            }
+        });
     }
 }
 
 // Event listeners
-conceptsButton.addEventListener('click', () => toggleSection(conceptsContent, conceptsArrow));
-toolsButton.addEventListener('click', () => toggleSection(toolsContent, toolsArrow));
+if (conceptsButton) conceptsButton.addEventListener('click', () => toggleSection(conceptsContent, conceptsArrow));
+if (toolsButton) toolsButton.addEventListener('click', () => toggleSection(toolsContent, toolsArrow));
+if (speedTestSectionButton) speedTestSectionButton.addEventListener('click', () => toggleSection(speedTestContent, speedTestArrow));
 
 restartButton.addEventListener('click', () => {
     currentStepId = 'start';
@@ -120,6 +143,123 @@ document.addEventListener('DOMContentLoaded', function() {
     // Add fade-in animation to the main container
     document.querySelector('.max-w-2xl').classList.add('animate-fadeIn');
 });
+
+// --- Speed Test Logic ---
+let speedTest = null;
+
+function initializeSpeedTest() {
+    if (!window.Speedtest) {
+        console.error("LibreSpeed Speedtest library não carregada.");
+        if(progressMessage) progressMessage.textContent = "Erro: Biblioteca de teste não carregada.";
+        return null;
+    }
+
+    speedTest = new Speedtest();
+
+    // Configure endpoints relative to where speedtest.js is located (lib/librespeed/)
+    speedTest.setParameter("download_endpoint", "garbage.txt");
+    speedTest.setParameter("upload_endpoint", "empty.txt");
+    speedTest.setParameter("ping_endpoint", "empty.txt");
+    speedTest.setParameter("worker_script", "speedtest_worker.js");
+    speedTest.setParameter("telemetry_level", "disabled"); // Disable telemetry
+
+    // Define callbacks
+    speedTest.onupdate = function(data) {
+        if(pingValue) pingValue.textContent = data.pingStatus || "-";
+        if(jitterValue) jitterValue.textContent = data.jitterStatus || "-";
+        // Ensure download/upload are numbers and format to 2 decimal places
+        if(downloadValue) downloadValue.textContent = data.dlStatus ? parseFloat(data.dlStatus).toFixed(2) : "-";
+        if(uploadValue) uploadValue.textContent = data.ulStatus ? parseFloat(data.ulStatus).toFixed(2) : "-";
+
+        let currentAction = "";
+        if (data.testState === 1 && data.dlStatus !== "0.00") currentAction = "Testando Download...";
+        else if (data.testState === 2 && data.ulStatus !== "0.00") currentAction = "Testando Upload...";
+        else if (data.testState === 3 && data.pingStatus !== "0.00") currentAction = "Testando Ping...";
+        else if (data.testState === 0 && !data.dlStatus) currentAction = "Preparando teste...";
+        else if (data.testState === -1) currentAction = "Aguardando para iniciar...";
+        else currentAction = "Processando...";
+
+        if(progressMessage) progressMessage.textContent = currentAction;
+    };
+
+    speedTest.onend = function(aborted) {
+        if(startSpeedTestButton) startSpeedTestButton.disabled = false;
+        if(startSpeedTestButton) startSpeedTestButton.textContent = "Iniciar Teste";
+        if (aborted) {
+            if(progressMessage) progressMessage.textContent = "Teste abortado.";
+            console.log("Teste abortado pelo usuário.");
+        } else {
+            if(progressMessage) progressMessage.textContent = "Teste Concluído!";
+            calculateAndDisplayPercentage();
+        }
+    };
+    return speedTest;
+}
+
+function handleStartSpeedTest() {
+    if (!speedTest) {
+        speedTest = initializeSpeedTest();
+        if (!speedTest) { // Failed to initialize
+             if(startSpeedTestButton) startSpeedTestButton.disabled = false;
+             if(startSpeedTestButton) startSpeedTestButton.textContent = "Iniciar Teste";
+            return;
+        }
+    }
+
+    // Clear previous results
+    if(pingValue) pingValue.textContent = "-";
+    if(jitterValue) jitterValue.textContent = "-";
+    if(downloadValue) downloadValue.textContent = "-";
+    if(uploadValue) uploadValue.textContent = "-";
+    if(percentageValue) percentageValue.textContent = "- %";
+    if(progressMessage) progressMessage.textContent = "Iniciando teste...";
+    if(percentageResultArea) percentageResultArea.classList.remove('animate-fadeIn');
+
+
+    if(startSpeedTestButton) startSpeedTestButton.disabled = true;
+    if(startSpeedTestButton) startSpeedTestButton.textContent = "Testando...";
+
+    try {
+        // Check if a test is already running, if so, abort and restart
+        if (speedTest.getState() > 0 && speedTest.getState() < 4) { // States 1,2,3 are active test states
+            speedTest.abort();
+        }
+        // Brief delay to ensure abort completes if it was called
+        setTimeout(() => {
+            speedTest.start();
+        }, 100);
+    } catch (e) {
+        console.error("Erro ao iniciar o teste:", e);
+        if(progressMessage) progressMessage.textContent = "Erro ao iniciar o teste.";
+        if(startSpeedTestButton) startSpeedTestButton.disabled = false;
+        if(startSpeedTestButton) startSpeedTestButton.textContent = "Iniciar Teste";
+    }
+}
+
+function calculateAndDisplayPercentage() {
+    const contracted = parseFloat(contractedSpeedInput ? contractedSpeedInput.value : "0");
+    const downloadSpeedText = downloadValue ? downloadValue.textContent : "0";
+    const downloadSpeed = parseFloat(downloadSpeedText);
+
+    if (contracted > 0 && downloadSpeed > 0) {
+        const percentage = (downloadSpeed / contracted) * 100;
+        if(percentageValue) percentageValue.textContent = percentage.toFixed(2) + " %";
+    } else {
+        if(percentageValue) percentageValue.textContent = "N/A";
+    }
+    if(percentageResultArea) {
+        percentageResultArea.classList.remove('animate-fadeIn'); // Remove to re-trigger animation
+        void percentageResultArea.offsetWidth; // Trigger reflow
+        percentageResultArea.classList.add('animate-fadeIn'); // Add animation
+    }
+}
+
+// Add event listener to the start speed test button
+if (startSpeedTestButton) {
+    startSpeedTestButton.addEventListener('click', handleStartSpeedTest);
+}
+
+// --- End of Speed Test Logic ---
 
 // Add service worker registration for PWA support
 if ('serviceWorker' in navigator) {

--- a/lib/librespeed/garbage.txt
+++ b/lib/librespeed/garbage.txt
@@ -1,0 +1,1 @@
+Este é um arquivo para teste de velocidade.

--- a/lib/librespeed/speedtest.js
+++ b/lib/librespeed/speedtest.js
@@ -1,0 +1,379 @@
+/*
+	LibreSpeed - Main
+	by Federico Dossena
+	https://github.com/librespeed/speedtest/
+	GNU LGPLv3 License
+*/
+
+/*
+   This is the main interface between your webpage and the speed test.
+   It hides the speed test web worker to the page, and provides many convenient functions to control the test.
+
+   The best way to learn how to use this is to look at the basic example, but here's some documentation.
+
+   To initialize the test, create a new Speedtest object:
+    let s=new Speedtest();
+   Now you can think of this as a finite state machine. These are the states (use getState() to see them):
+   - 0: here you can change the speed test settings (such as test duration) with the setParameter("parameter",value) method. From here you can either start the test using start() (goes to state 3) or you can add multiple test points using addTestPoint(server) or addTestPoints(serverList) (goes to state 1). Additionally, this is the perfect moment to set up callbacks for the onupdate(data) and onend(aborted) events.
+   - 1: here you can add test points. You only need to do this if you want to use multiple test points.
+        A server is defined as an object like this:
+        {
+            name: "User friendly name",
+            server:"http://yourBackend.com/",     <---- URL to your server. You can specify http:// or https://. If your server supports both, just write // without the protocol
+            dlURL:"garbage.php"    <----- path to garbage.php or its replacement on the server
+            ulURL:"empty.php"    <----- path to empty.php or its replacement on the server
+            pingURL:"empty.php"    <----- path to empty.php or its replacement on the server. This is used to ping the server by this selector
+            getIpURL:"getIP.php"    <----- path to getIP.php or its replacement on the server
+        }
+        While in state 1, you can only add test points, you cannot change the test settings. When you're done, use selectServer(callback) to select the test point with the lowest ping. This is asynchronous, when it's done, it will call your callback function and move to state 2. Calling setSelectedServer(server) will manually select a server and move to state 2.
+    - 2: test point selected, ready to start the test. Use start() to begin, this will move to state 3
+    - 3: test running. Here, your onupdate event callback will be called periodically, with data coming from the worker about speed and progress. A data object will be passed to your onupdate function, with the following items:
+            - dlStatus: download speed in Mbit/s
+            - ulStatus: upload speed in Mbit/s
+            - pingStatus: ping in ms
+            - jitterStatus: jitter in ms
+            - dlProgress: progress of the download test as a float 0-1
+            - ulProgress: progress of the upload test as a float 0-1
+            - pingProgress: progress of the ping/jitter test as a float 0-1
+            - testState: state of the test (-1=not started, 0=starting, 1=download test, 2=ping+jitter test, 3=upload test, 4=finished, 5=aborted)
+            - clientIp: IP address of the client performing the test (and optionally ISP and distance)
+        At the end of the test, the onend function will be called, with a boolean specifying whether the test was aborted or if it ended normally.
+        The test can be aborted at any time with abort().
+        At the end of the test, it will move to state 4
+    - 4: test finished. You can run it again by calling start() if you want.
+ */
+
+function Speedtest() {
+  this._serverList = []; //when using multiple points of test, this is a list of test points
+  this._selectedServer = null; //when using multiple points of test, this is the selected server
+  this._settings = {}; //settings for the speed test worker
+  this._state = 0; //0=adding settings, 1=adding servers, 2=server selection done, 3=test running, 4=done
+  console.log(
+    "LibreSpeed by Federico Dossena v5.4.1 - https://github.com/librespeed/speedtest"
+  );
+}
+
+Speedtest.prototype = {
+  constructor: Speedtest,
+  /**
+   * Returns the state of the test: 0=adding settings, 1=adding servers, 2=server selection done, 3=test running, 4=done
+   */
+  getState: function() {
+    return this._state;
+  },
+  /**
+   * Change one of the test settings from their defaults.
+   * - parameter: string with the name of the parameter that you want to set
+   * - value: new value for the parameter
+   *
+   * Invalid values or nonexistant parameters will be ignored by the speed test worker.
+   */
+  setParameter: function(parameter, value) {
+    if (this._state == 3)
+      throw "You cannot change the test settings while running the test";
+    this._settings[parameter] = value;
+    if(parameter === "telemetry_extra"){
+        this._originalExtra=this._settings.telemetry_extra;
+    }
+  },
+  /**
+   * Used internally to check if a server object contains all the required elements.
+   * Also fixes the server URL if needed.
+   */
+  _checkServerDefinition: function(server) {
+    try {
+      if (typeof server.name !== "string")
+        throw "Name string missing from server definition (name)";
+      if (typeof server.server !== "string")
+        throw "Server address string missing from server definition (server)";
+      if (server.server.charAt(server.server.length - 1) != "/")
+        server.server += "/";
+      if (server.server.indexOf("//") == 0)
+        server.server = location.protocol + server.server;
+      if (typeof server.dlURL !== "string")
+        throw "Download URL string missing from server definition (dlURL)";
+      if (typeof server.ulURL !== "string")
+        throw "Upload URL string missing from server definition (ulURL)";
+      if (typeof server.pingURL !== "string")
+        throw "Ping URL string missing from server definition (pingURL)";
+      if (typeof server.getIpURL !== "string")
+        throw "GetIP URL string missing from server definition (getIpURL)";
+    } catch (e) {
+      throw "Invalid server definition";
+    }
+  },
+  /**
+   * Add a test point (multiple points of test)
+   * server: the server to be added as an object. Must contain the following elements:
+   *  {
+   *       name: "User friendly name",
+   *       server:"http://yourBackend.com/",   URL to your server. You can specify http:// or https://. If your server supports both, just write // without the protocol
+   *       dlURL:"garbage.php"   path to garbage.php or its replacement on the server
+   *       ulURL:"empty.php"   path to empty.php or its replacement on the server
+   *       pingURL:"empty.php"   path to empty.php or its replacement on the server. This is used to ping the server by this selector
+   *       getIpURL:"getIP.php"   path to getIP.php or its replacement on the server
+   *   }
+   */
+  addTestPoint: function(server) {
+    this._checkServerDefinition(server);
+    if (this._state == 0) this._state = 1;
+    if (this._state != 1) throw "You can't add a server after server selection";
+    this._settings.mpot = true;
+    this._serverList.push(server);
+  },
+  /**
+   * Same as addTestPoint, but you can pass an array of servers
+   */
+  addTestPoints: function(list) {
+    for (let i = 0; i < list.length; i++) this.addTestPoint(list[i]);
+  },
+  /**
+   * Load a JSON server list from URL (multiple points of test)
+   * url: the url where the server list can be fetched. Must be an array with objects containing the following elements:
+   *  {
+   *       "name": "User friendly name",
+   *       "server":"http://yourBackend.com/",   URL to your server. You can specify http:// or https://. If your server supports both, just write // without the protocol
+   *       "dlURL":"garbage.php"   path to garbage.php or its replacement on the server
+   *       "ulURL":"empty.php"   path to empty.php or its replacement on the server
+   *       "pingURL":"empty.php"   path to empty.php or its replacement on the server. This is used to ping the server by this selector
+   *       "getIpURL":"getIP.php"   path to getIP.php or its replacement on the server
+   *   }
+   * result: callback to be called when the list is loaded correctly. An array with the loaded servers will be passed to this function, or null if it failed
+   */
+  loadServerList: function(url,result) {
+    if (this._state == 0) this._state = 1;
+    if (this._state != 1) throw "You can't add a server after server selection";
+    this._settings.mpot = true;
+    let xhr = new XMLHttpRequest();
+    xhr.onload = function(){
+      try{
+        const servers=JSON.parse(xhr.responseText);
+        for(let i=0;i<servers.length;i++){
+          this._checkServerDefinition(servers[i]);
+        }
+        this.addTestPoints(servers);
+        result(servers);
+      }catch(e){
+        result(null);
+      }
+    }.bind(this);
+    xhr.onerror = function(){result(null);}
+    xhr.open("GET",url);
+    xhr.send();
+  },
+  /**
+   * Returns the selected server (multiple points of test)
+   */
+  getSelectedServer: function() {
+    if (this._state < 2 || this._selectedServer == null)
+      throw "No server is selected";
+    return this._selectedServer;
+  },
+  /**
+   * Manually selects one of the test points (multiple points of test)
+   */
+  setSelectedServer: function(server) {
+    this._checkServerDefinition(server);
+    if (this._state == 3)
+      throw "You can't select a server while the test is running";
+    this._selectedServer = server;
+    this._state = 2;
+  },
+  /**
+   * Automatically selects a server from the list of added test points. The server with the lowest ping will be chosen. (multiple points of test)
+   * The process is asynchronous and the passed result callback function will be called when it's done, then the test can be started.
+   */
+  selectServer: function(result) {
+    if (this._state != 1) {
+      if (this._state == 0) throw "No test points added";
+      if (this._state == 2) throw "Server already selected";
+      if (this._state >= 3)
+        throw "You can't select a server while the test is running";
+    }
+    if (this._selectServerCalled) throw "selectServer already called"; else this._selectServerCalled=true;
+    /*this function goes through a list of servers. For each server, the ping is measured, then the server with the function selected is called with the best server, or null if all the servers were down.
+     */
+    const select = function(serverList, selected) {
+      //pings the specified URL, then calls the function result. Result will receive a parameter which is either the time it took to ping the URL, or -1 if something went wrong.
+      const PING_TIMEOUT = 2000;
+      let USE_PING_TIMEOUT = true; //will be disabled on unsupported browsers
+      if (/MSIE.(\d+\.\d+)/i.test(navigator.userAgent)) {
+        //IE11 doesn't support XHR timeout
+        USE_PING_TIMEOUT = false;
+      }
+      const ping = function(url, rtt) {
+        url += (url.match(/\?/) ? "&" : "?") + "cors=true";
+        let xhr = new XMLHttpRequest();
+        let t = new Date().getTime();
+        xhr.onload = function() {
+          if (xhr.responseText.length == 0) {
+            //we expect an empty response
+            let instspd = new Date().getTime() - t; //rough timing estimate
+            try {
+              //try to get more accurate timing using performance API
+              let p = performance.getEntriesByName(url);
+              p = p[p.length - 1];
+              let d = p.responseStart - p.requestStart;
+              if (d <= 0) d = p.duration;
+              if (d > 0 && d < instspd) instspd = d;
+            } catch (e) {}
+            rtt(instspd);
+          } else rtt(-1);
+        }.bind(this);
+        xhr.onerror = function() {
+          rtt(-1);
+        }.bind(this);
+        xhr.open("GET", url);
+        if (USE_PING_TIMEOUT) {
+          try {
+            xhr.timeout = PING_TIMEOUT;
+            xhr.ontimeout = xhr.onerror;
+          } catch (e) {}
+        }
+        xhr.send();
+      }.bind(this);
+
+      //this function repeatedly pings a server to get a good estimate of the ping. When it's done, it calls the done function without parameters. At the end of the execution, the server will have a new parameter called pingT, which is either the best ping we got from the server or -1 if something went wrong.
+      const PINGS = 3, //up to 3 pings are performed, unless the server is down...
+        SLOW_THRESHOLD = 500; //...or one of the pings is above this threshold
+      const checkServer = function(server, done) {
+        let i = 0;
+        server.pingT = -1;
+        if (server.server.indexOf(location.protocol) == -1) done();
+        else {
+          const nextPing = function() {
+            if (i++ == PINGS) {
+              done();
+              return;
+            }
+            ping(
+              server.server + server.pingURL,
+              function(t) {
+                if (t >= 0) {
+                  if (t < server.pingT || server.pingT == -1) server.pingT = t;
+                  if (t < SLOW_THRESHOLD) nextPing();
+                  else done();
+                } else done();
+              }.bind(this)
+            );
+          }.bind(this);
+          nextPing();
+        }
+      }.bind(this);
+      //check servers in list, one by one
+      let i = 0;
+      const done = function() {
+        let bestServer = null;
+        for (let i = 0; i < serverList.length; i++) {
+          if (
+            serverList[i].pingT != -1 &&
+            (bestServer == null || serverList[i].pingT < bestServer.pingT)
+          )
+            bestServer = serverList[i];
+        }
+        selected(bestServer);
+      }.bind(this);
+      const nextServer = function() {
+        if (i == serverList.length) {
+          done();
+          return;
+        }
+        checkServer(serverList[i++], nextServer);
+      }.bind(this);
+      nextServer();
+    }.bind(this);
+
+    //parallel server selection
+    const CONCURRENCY = 6;
+    let serverLists = [];
+    for (let i = 0; i < CONCURRENCY; i++) {
+      serverLists[i] = [];
+    }
+    for (let i = 0; i < this._serverList.length; i++) {
+      serverLists[i % CONCURRENCY].push(this._serverList[i]);
+    }
+    let completed = 0;
+    let bestServer = null;
+    for (let i = 0; i < CONCURRENCY; i++) {
+      select(
+        serverLists[i],
+        function(server) {
+          if (server != null) {
+            if (bestServer == null || server.pingT < bestServer.pingT)
+              bestServer = server;
+          }
+          completed++;
+          if (completed == CONCURRENCY) {
+            this._selectedServer = bestServer;
+            this._state = 2;
+            if (result) result(bestServer);
+          }
+        }.bind(this)
+      );
+    }
+  },
+  /**
+   * Starts the test.
+   * During the test, the onupdate(data) callback function will be called periodically with data from the worker.
+   * At the end of the test, the onend(aborted) function will be called with a boolean telling you if the test was aborted or if it ended normally.
+   */
+  start: function() {
+    if (this._state == 3) throw "Test already running";
+    this.worker = new Worker("speedtest_worker.js?r=" + Math.random());
+    this.worker.onmessage = function(e) {
+      if (e.data === this._prevData) return;
+      else this._prevData = e.data;
+      const data = JSON.parse(e.data);
+      try {
+        if (this.onupdate) this.onupdate(data);
+      } catch (e) {
+        console.error("Speedtest onupdate event threw exception: " + e);
+      }
+      if (data.testState >= 4) {
+	  clearInterval(this.updater);
+        this._state = 4;
+        try {
+          if (this.onend) this.onend(data.testState == 5);
+        } catch (e) {
+          console.error("Speedtest onend event threw exception: " + e);
+        }
+      }
+    }.bind(this);
+    this.updater = setInterval(
+      function() {
+        this.worker.postMessage("status");
+      }.bind(this),
+      200
+    );
+    if (this._state == 1)
+        throw "When using multiple points of test, you must call selectServer before starting the test";
+    if (this._state == 2) {
+      this._settings.url_dl =
+        this._selectedServer.server + this._selectedServer.dlURL;
+      this._settings.url_ul =
+        this._selectedServer.server + this._selectedServer.ulURL;
+      this._settings.url_ping =
+        this._selectedServer.server + this._selectedServer.pingURL;
+      this._settings.url_getIp =
+        this._selectedServer.server + this._selectedServer.getIpURL;
+      if (typeof this._originalExtra !== "undefined") {
+        this._settings.telemetry_extra = JSON.stringify({
+          server: this._selectedServer.name,
+          extra: this._originalExtra
+        });
+      } else
+        this._settings.telemetry_extra = JSON.stringify({
+          server: this._selectedServer.name
+        });
+    }
+    this._state = 3;
+    this.worker.postMessage("start " + JSON.stringify(this._settings));
+  },
+  /**
+   * Aborts the test while it's running.
+   */
+  abort: function() {
+    if (this._state < 3) throw "You cannot abort a test that's not started yet";
+    if (this._state < 4) this.worker.postMessage("abort");
+  }
+};

--- a/lib/librespeed/speedtest_worker.js
+++ b/lib/librespeed/speedtest_worker.js
@@ -1,0 +1,724 @@
+/*
+	LibreSpeed - Worker
+	by Federico Dossena
+	https://github.com/librespeed/speedtest/
+	GNU LGPLv3 License
+*/
+
+// data reported to main thread
+let testState = -1; // -1=not started, 0=starting, 1=download test, 2=ping+jitter test, 3=upload test, 4=finished, 5=abort
+let dlStatus = ""; // download speed in megabit/s with 2 decimal digits
+let ulStatus = ""; // upload speed in megabit/s with 2 decimal digits
+let pingStatus = ""; // ping in milliseconds with 2 decimal digits
+let jitterStatus = ""; // jitter in milliseconds with 2 decimal digits
+let clientIp = ""; // client's IP address as reported by getIP.php
+let dlProgress = 0; //progress of download test 0-1
+let ulProgress = 0; //progress of upload test 0-1
+let pingProgress = 0; //progress of ping+jitter test 0-1
+let testId = null; //test ID (sent back by telemetry if used, null otherwise)
+
+let log = ""; //telemetry log
+function tlog(s) {
+	if (settings.telemetry_level >= 2) {
+		log += Date.now() + ": " + s + "\n";
+	}
+}
+function tverb(s) {
+	if (settings.telemetry_level >= 3) {
+		log += Date.now() + ": " + s + "\n";
+	}
+}
+function twarn(s) {
+	if (settings.telemetry_level >= 2) {
+		log += Date.now() + " WARN: " + s + "\n";
+	}
+	console.warn(s);
+}
+
+// test settings. can be overridden by sending specific values with the start command
+let settings = {
+	mpot: false, //set to true when in MPOT mode
+	test_order: "IP_D_U", //order in which tests will be performed as a string. D=Download, U=Upload, P=Ping+Jitter, I=IP, _=1 second delay
+	time_ul_max: 15, // max duration of upload test in seconds
+	time_dl_max: 15, // max duration of download test in seconds
+	time_auto: true, // if set to true, tests will take less time on faster connections
+	time_ulGraceTime: 3, //time to wait in seconds before actually measuring ul speed (wait for buffers to fill)
+	time_dlGraceTime: 1.5, //time to wait in seconds before actually measuring dl speed (wait for TCP window to increase)
+	count_ping: 10, // number of pings to perform in ping test
+	url_dl: "backend/garbage.php", // path to a large file or garbage.php, used for download test. must be relative to this js file
+	url_ul: "backend/empty.php", // path to an empty file, used for upload test. must be relative to this js file
+	url_ping: "backend/empty.php", // path to an empty file, used for ping test. must be relative to this js file
+	url_getIp: "backend/getIP.php", // path to getIP.php relative to this js file, or a similar thing that outputs the client's ip
+	getIp_ispInfo: true, //if set to true, the server will include ISP info with the IP address
+	getIp_ispInfo_distance: "km", //km or mi=estimate distance from server in km/mi; set to false to disable distance estimation. getIp_ispInfo must be enabled in order for this to work
+	xhr_dlMultistream: 6, // number of download streams to use (can be different if enable_quirks is active)
+	xhr_ulMultistream: 3, // number of upload streams to use (can be different if enable_quirks is active)
+	xhr_multistreamDelay: 300, //how much concurrent requests should be delayed
+	xhr_ignoreErrors: 1, // 0=fail on errors, 1=attempt to restart a stream if it fails, 2=ignore all errors
+	xhr_dlUseBlob: false, // if set to true, it reduces ram usage but uses the hard drive (useful with large garbagePhp_chunkSize and/or high xhr_dlMultistream)
+	xhr_ul_blob_megabytes: 20, //size in megabytes of the upload blobs sent in the upload test (forced to 4 on chrome mobile)
+	garbagePhp_chunkSize: 100, // size of chunks sent by garbage.php (can be different if enable_quirks is active)
+	enable_quirks: true, // enable quirks for specific browsers. currently it overrides settings to optimize for specific browsers, unless they are already being overridden with the start command
+	ping_allowPerformanceApi: true, // if enabled, the ping test will attempt to calculate the ping more precisely using the Performance API. Currently works perfectly in Chrome, badly in Edge, and not at all in Firefox. If Performance API is not supported or the result is obviously wrong, a fallback is provided.
+	overheadCompensationFactor: 1.06, //can be changed to compensate for transport overhead. (see doc.md for some other values)
+	useMebibits: false, //if set to true, speed will be reported in mebibits/s instead of megabits/s
+	telemetry_level: 0, // 0=disabled, 1=basic (results only), 2=full (results and timing) 3=debug (results+log)
+	url_telemetry: "results/telemetry.php", // path to the script that adds telemetry data to the database
+	telemetry_extra: "", //extra data that can be passed to the telemetry through the settings
+    forceIE11Workaround: false //when set to true, it will force the IE11 upload test on all browsers. Debug only
+};
+
+let xhr = null; // array of currently active xhr requests
+let interval = null; // timer used in tests
+let test_pointer = 0; //pointer to the next test to run inside settings.test_order
+
+/*
+  this function is used on URLs passed in the settings to determine whether we need a ? or an & as a separator
+*/
+function url_sep(url) {
+	return url.match(/\?/) ? "&" : "?";
+}
+
+/*
+	listener for commands from main thread to this worker.
+	commands:
+	-status: returns the current status as a JSON string containing testState, dlStatus, ulStatus, pingStatus, clientIp, jitterStatus, dlProgress, ulProgress, pingProgress
+	-abort: aborts the current test
+	-start: starts the test. optionally, settings can be passed as JSON.
+		example: start {"time_ul_max":"10", "time_dl_max":"10", "count_ping":"50"}
+*/
+this.addEventListener("message", function(e) {
+	const params = e.data.split(" ");
+	if (params[0] === "status") {
+		// return status
+		postMessage(
+			JSON.stringify({
+				testState: testState,
+				dlStatus: dlStatus,
+				ulStatus: ulStatus,
+				pingStatus: pingStatus,
+				clientIp: clientIp,
+				jitterStatus: jitterStatus,
+				dlProgress: dlProgress,
+				ulProgress: ulProgress,
+				pingProgress: pingProgress,
+				testId: testId
+			})
+		);
+	}
+	if (params[0] === "start" && testState === -1) {
+		// start new test
+		testState = 0;
+		try {
+			// parse settings, if present
+			let s = {};
+			try {
+				const ss = e.data.substring(5);
+				if (ss) s = JSON.parse(ss);
+			} catch (e) {
+				twarn("Error parsing custom settings JSON. Please check your syntax");
+			}
+			//copy custom settings
+			for (let key in s) {
+				if (typeof settings[key] !== "undefined") settings[key] = s[key];
+				else twarn("Unknown setting ignored: " + key);
+			}
+			const ua = navigator.userAgent;
+			// quirks for specific browsers. apply only if not overridden. more may be added in future releases
+			if (settings.enable_quirks || (typeof s.enable_quirks !== "undefined" && s.enable_quirks)) {
+				if (/Firefox.(\d+\.\d+)/i.test(ua)) {
+					if (typeof s.ping_allowPerformanceApi === "undefined") {
+						// ff performance API sucks
+						settings.ping_allowPerformanceApi = false;
+					}
+				}
+				if (/Edge.(\d+\.\d+)/i.test(ua)) {
+					if (typeof s.xhr_dlMultistream === "undefined") {
+						// edge more precise with 3 download streams
+						settings.xhr_dlMultistream = 3;
+					}
+				}
+				if (/Chrome.(\d+)/i.test(ua) && !!self.fetch) {
+					if (typeof s.xhr_dlMultistream === "undefined") {
+						// chrome more precise with 5 streams
+						settings.xhr_dlMultistream = 5;
+					}
+				}
+			}
+			if (/Edge.(\d+\.\d+)/i.test(ua)) {
+				//Edge 15 introduced a bug that causes onprogress events to not get fired, we have to use the "small chunks" workaround that reduces accuracy
+				settings.forceIE11Workaround = true;
+			}
+			if (/PlayStation 4.(\d+\.\d+)/i.test(ua)) {
+				//PS4 browser has the same bug as IE11/Edge
+				settings.forceIE11Workaround = true;
+			}
+			if (/Chrome.(\d+)/i.test(ua) && /Android|iPhone|iPad|iPod|Windows Phone/i.test(ua)) {
+				//cheap af
+				//Chrome mobile introduced a limitation somewhere around version 65, we have to limit XHR upload size to 4 megabytes
+				settings.xhr_ul_blob_megabytes = 4;
+			}
+			if (/^((?!chrome|android|crios|fxios).)*safari/i.test(ua)) {
+				//Safari also needs the IE11 workaround but only for the MPOT version
+				settings.forceIE11Workaround = true;
+			}
+			//telemetry_level has to be parsed and not just copied
+			if (typeof s.telemetry_level !== "undefined") settings.telemetry_level = s.telemetry_level === "basic" ? 1 : s.telemetry_level === "full" ? 2 : s.telemetry_level === "debug" ? 3 : 0; // telemetry level
+			//transform test_order to uppercase, just in case
+			settings.test_order = settings.test_order.toUpperCase();
+		} catch (e) {
+			twarn("Possible error in custom test settings. Some settings might not have been applied. Exception: " + e);
+		}
+		// run the tests
+		tverb(JSON.stringify(settings));
+		test_pointer = 0;
+		let iRun = false,
+			dRun = false,
+			uRun = false,
+			pRun = false;
+		const runNextTest = function() {
+			if (testState == 5) return;
+			if (test_pointer >= settings.test_order.length) {
+				//test is finished
+				if (settings.telemetry_level > 0)
+					sendTelemetry(function(id) {
+						testState = 4;
+						if (id != null) testId = id;
+					});
+				else testState = 4;
+				return;
+			}
+			switch (settings.test_order.charAt(test_pointer)) {
+				case "I":
+					{
+						test_pointer++;
+						if (iRun) {
+							runNextTest();
+							return;
+						} else iRun = true;
+						getIp(runNextTest);
+					}
+					break;
+				case "D":
+					{
+						test_pointer++;
+						if (dRun) {
+							runNextTest();
+							return;
+						} else dRun = true;
+						testState = 1;
+						dlTest(runNextTest);
+					}
+					break;
+				case "U":
+					{
+						test_pointer++;
+						if (uRun) {
+							runNextTest();
+							return;
+						} else uRun = true;
+						testState = 3;
+						ulTest(runNextTest);
+					}
+					break;
+				case "P":
+					{
+						test_pointer++;
+						if (pRun) {
+							runNextTest();
+							return;
+						} else pRun = true;
+						testState = 2;
+						pingTest(runNextTest);
+					}
+					break;
+				case "_":
+					{
+						test_pointer++;
+						setTimeout(runNextTest, 1000);
+					}
+					break;
+				default:
+					test_pointer++;
+			}
+		};
+		runNextTest();
+	}
+	if (params[0] === "abort") {
+		// abort command
+        if (testState >= 4) return;
+		tlog("manually aborted");
+		clearRequests(); // stop all xhr activity
+		runNextTest = null;
+		if (interval) clearInterval(interval); // clear timer if present
+		if (settings.telemetry_level > 1) sendTelemetry(function() {});
+		testState = 5; //set test as aborted
+		dlStatus = "";
+		ulStatus = "";
+		pingStatus = "";
+		jitterStatus = "";
+        clientIp = "";
+		dlProgress = 0;
+		ulProgress = 0;
+		pingProgress = 0;
+	}
+});
+// stops all XHR activity, aggressively
+function clearRequests() {
+	tverb("stopping pending XHRs");
+	if (xhr) {
+		for (let i = 0; i < xhr.length; i++) {
+			try {
+				xhr[i].onprogress = null;
+				xhr[i].onload = null;
+				xhr[i].onerror = null;
+			} catch (e) {}
+			try {
+				xhr[i].upload.onprogress = null;
+				xhr[i].upload.onload = null;
+				xhr[i].upload.onerror = null;
+			} catch (e) {}
+			try {
+				xhr[i].abort();
+			} catch (e) {}
+			try {
+				delete xhr[i];
+			} catch (e) {}
+		}
+		xhr = null;
+	}
+}
+// gets client's IP using url_getIp, then calls the done function
+let ipCalled = false; // used to prevent multiple accidental calls to getIp
+let ispInfo = ""; //used for telemetry
+function getIp(done) {
+	tverb("getIp");
+	if (ipCalled) return;
+	else ipCalled = true; // getIp already called?
+	let startT = new Date().getTime();
+	xhr = new XMLHttpRequest();
+	xhr.onload = function() {
+		tlog("IP: " + xhr.responseText + ", took " + (new Date().getTime() - startT) + "ms");
+		try {
+			const data = JSON.parse(xhr.responseText);
+			clientIp = data.processedString;
+			ispInfo = data.rawIspInfo;
+		} catch (e) {
+			clientIp = xhr.responseText;
+			ispInfo = "";
+		}
+		done();
+	};
+	xhr.onerror = function() {
+		tlog("getIp failed, took " + (new Date().getTime() - startT) + "ms");
+		done();
+	};
+	xhr.open("GET", settings.url_getIp + url_sep(settings.url_getIp) + (settings.mpot ? "cors=true&" : "") + (settings.getIp_ispInfo ? "isp=true" + (settings.getIp_ispInfo_distance ? "&distance=" + settings.getIp_ispInfo_distance + "&" : "&") : "&") + "r=" + Math.random(), true);
+	xhr.send();
+}
+// download test, calls done function when it's over
+let dlCalled = false; // used to prevent multiple accidental calls to dlTest
+function dlTest(done) {
+	tverb("dlTest");
+	if (dlCalled) return;
+	else dlCalled = true; // dlTest already called?
+	let totLoaded = 0.0, // total number of loaded bytes
+		startT = new Date().getTime(), // timestamp when test was started
+		bonusT = 0, //how many milliseconds the test has been shortened by (higher on faster connections)
+		graceTimeDone = false, //set to true after the grace time is past
+		failed = false; // set to true if a stream fails
+	xhr = [];
+	// function to create a download stream. streams are slightly delayed so that they will not end at the same time
+	const testStream = function(i, delay) {
+		setTimeout(
+			function() {
+				if (testState !== 1) return; // delayed stream ended up starting after the end of the download test
+				tverb("dl test stream started " + i + " " + delay);
+				let prevLoaded = 0; // number of bytes loaded last time onprogress was called
+				let x = new XMLHttpRequest();
+				xhr[i] = x;
+				xhr[i].onprogress = function(event) {
+					tverb("dl stream progress event " + i + " " + event.loaded);
+					if (testState !== 1) {
+						try {
+							x.abort();
+						} catch (e) {}
+					} // just in case this XHR is still running after the download test
+					// progress event, add number of new loaded bytes to totLoaded
+					const loadDiff = event.loaded <= 0 ? 0 : event.loaded - prevLoaded;
+					if (isNaN(loadDiff) || !isFinite(loadDiff) || loadDiff < 0) return; // just in case
+					totLoaded += loadDiff;
+					prevLoaded = event.loaded;
+				}.bind(this);
+				xhr[i].onload = function() {
+					// the large file has been loaded entirely, start again
+					tverb("dl stream finished " + i);
+					try {
+						xhr[i].abort();
+					} catch (e) {} // reset the stream data to empty ram
+					testStream(i, 0);
+				}.bind(this);
+				xhr[i].onerror = function() {
+					// error
+					tverb("dl stream failed " + i);
+					if (settings.xhr_ignoreErrors === 0) failed = true; //abort
+					try {
+						xhr[i].abort();
+					} catch (e) {}
+					delete xhr[i];
+					if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
+				}.bind(this);
+				// send xhr
+				try {
+					if (settings.xhr_dlUseBlob) xhr[i].responseType = "blob";
+					else xhr[i].responseType = "arraybuffer";
+				} catch (e) {}
+				xhr[i].open("GET", settings.url_dl + url_sep(settings.url_dl) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random() + "&ckSize=" + settings.garbagePhp_chunkSize, true); // random string to prevent caching
+				xhr[i].send();
+			}.bind(this),
+			1 + delay
+		);
+	}.bind(this);
+	// open streams
+	for (let i = 0; i < settings.xhr_dlMultistream; i++) {
+		testStream(i, settings.xhr_multistreamDelay * i);
+	}
+	// every 200ms, update dlStatus
+	interval = setInterval(
+		function() {
+			tverb("DL: " + dlStatus + (graceTimeDone ? "" : " (in grace time)"));
+			const t = new Date().getTime() - startT;
+			if (graceTimeDone) dlProgress = (t + bonusT) / (settings.time_dl_max * 1000);
+			if (t < 200) return;
+			if (!graceTimeDone) {
+				if (t > 1000 * settings.time_dlGraceTime) {
+					if (totLoaded > 0) {
+						// if the connection is so slow that we didn't get a single chunk yet, do not reset
+						startT = new Date().getTime();
+						bonusT = 0;
+						totLoaded = 0.0;
+					}
+					graceTimeDone = true;
+				}
+			} else {
+				const speed = totLoaded / (t / 1000.0);
+				if (settings.time_auto) {
+					//decide how much to shorten the test. Every 200ms, the test is shortened by the bonusT calculated here
+					const bonus = (5.0 * speed) / 100000;
+					bonusT += bonus > 400 ? 400 : bonus;
+				}
+				//update status
+				dlStatus = ((speed * 8 * settings.overheadCompensationFactor) / (settings.useMebibits ? 1048576 : 1000000)).toFixed(2); // speed is multiplied by 8 to go from bytes to bits, overhead compensation is applied, then everything is divided by 1048576 or 1000000 to go to megabits/mebibits
+				if ((t + bonusT) / 1000.0 > settings.time_dl_max || failed) {
+					// test is over, stop streams and timer
+					if (failed || isNaN(dlStatus)) dlStatus = "Fail";
+					clearRequests();
+					clearInterval(interval);
+					dlProgress = 1;
+					tlog("dlTest: " + dlStatus + ", took " + (new Date().getTime() - startT) + "ms");
+					done();
+				}
+			}
+		}.bind(this),
+		200
+	);
+}
+// upload test, calls done function when it's over
+let ulCalled = false; // used to prevent multiple accidental calls to ulTest
+function ulTest(done) {
+	tverb("ulTest");
+	if (ulCalled) return;
+	else ulCalled = true; // ulTest already called?
+	// garbage data for upload test
+	let r = new ArrayBuffer(1048576);
+	const maxInt = Math.pow(2, 32) - 1;
+	try {
+		r = new Uint32Array(r);
+		for (let i = 0; i < r.length; i++) r[i] = Math.random() * maxInt;
+	} catch (e) {}
+	let req = [];
+	let reqsmall = [];
+	for (let i = 0; i < settings.xhr_ul_blob_megabytes; i++) req.push(r);
+	req = new Blob(req);
+	r = new ArrayBuffer(262144);
+	try {
+		r = new Uint32Array(r);
+		for (let i = 0; i < r.length; i++) r[i] = Math.random() * maxInt;
+	} catch (e) {}
+	reqsmall.push(r);
+	reqsmall = new Blob(reqsmall);
+	const testFunction = function() {
+		let totLoaded = 0.0, // total number of transmitted bytes
+			startT = new Date().getTime(), // timestamp when test was started
+			bonusT = 0, //how many milliseconds the test has been shortened by (higher on faster connections)
+			graceTimeDone = false, //set to true after the grace time is past
+			failed = false; // set to true if a stream fails
+		xhr = [];
+		// function to create an upload stream. streams are slightly delayed so that they will not end at the same time
+		const testStream = function(i, delay) {
+			setTimeout(
+				function() {
+					if (testState !== 3) return; // delayed stream ended up starting after the end of the upload test
+					tverb("ul test stream started " + i + " " + delay);
+					let prevLoaded = 0; // number of bytes transmitted last time onprogress was called
+					let x = new XMLHttpRequest();
+					xhr[i] = x;
+					let ie11workaround;
+					if (settings.forceIE11Workaround) ie11workaround = true;
+					else {
+						try {
+							xhr[i].upload.onprogress;
+							ie11workaround = false;
+						} catch (e) {
+							ie11workaround = true;
+						}
+					}
+					if (ie11workaround) {
+						// IE11 workaround: xhr.upload does not work properly, therefore we send a bunch of small 256k requests and use the onload event as progress. This is not precise, especially on fast connections
+						xhr[i].onload = xhr[i].onerror = function() {
+							tverb("ul stream progress event (ie11wa)");
+							totLoaded += reqsmall.size;
+							testStream(i, 0);
+						};
+						xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true); // random string to prevent caching
+						try {
+							xhr[i].setRequestHeader("Content-Encoding", "identity"); // disable compression (some browsers may refuse it, but data is incompressible anyway)
+						} catch (e) {}
+						//No Content-Type header in MPOT branch because it triggers bugs in some browsers
+						xhr[i].send(reqsmall);
+					} else {
+						// REGULAR version, no workaround
+						xhr[i].upload.onprogress = function(event) {
+							tverb("ul stream progress event " + i + " " + event.loaded);
+							if (testState !== 3) {
+								try {
+									x.abort();
+								} catch (e) {}
+							} // just in case this XHR is still running after the upload test
+							// progress event, add number of new loaded bytes to totLoaded
+							const loadDiff = event.loaded <= 0 ? 0 : event.loaded - prevLoaded;
+							if (isNaN(loadDiff) || !isFinite(loadDiff) || loadDiff < 0) return; // just in case
+							totLoaded += loadDiff;
+							prevLoaded = event.loaded;
+						}.bind(this);
+						xhr[i].upload.onload = function() {
+							// this stream sent all the garbage data, start again
+							tverb("ul stream finished " + i);
+							testStream(i, 0);
+						}.bind(this);
+						xhr[i].upload.onerror = function() {
+							tverb("ul stream failed " + i);
+							if (settings.xhr_ignoreErrors === 0) failed = true; //abort
+							try {
+								xhr[i].abort();
+							} catch (e) {}
+							delete xhr[i];
+							if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
+						}.bind(this);
+						// send xhr
+						xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true); // random string to prevent caching
+						try {
+							xhr[i].setRequestHeader("Content-Encoding", "identity"); // disable compression (some browsers may refuse it, but data is incompressible anyway)
+						} catch (e) {}
+						//No Content-Type header in MPOT branch because it triggers bugs in some browsers
+						xhr[i].send(req);
+					}
+				}.bind(this),
+				delay
+			);
+		}.bind(this);
+		// open streams
+		for (let i = 0; i < settings.xhr_ulMultistream; i++) {
+			testStream(i, settings.xhr_multistreamDelay * i);
+		}
+		// every 200ms, update ulStatus
+		interval = setInterval(
+			function() {
+				tverb("UL: " + ulStatus + (graceTimeDone ? "" : " (in grace time)"));
+				const t = new Date().getTime() - startT;
+				if (graceTimeDone) ulProgress = (t + bonusT) / (settings.time_ul_max * 1000);
+				if (t < 200) return;
+				if (!graceTimeDone) {
+					if (t > 1000 * settings.time_ulGraceTime) {
+						if (totLoaded > 0) {
+							// if the connection is so slow that we didn't get a single chunk yet, do not reset
+							startT = new Date().getTime();
+							bonusT = 0;
+							totLoaded = 0.0;
+						}
+						graceTimeDone = true;
+					}
+				} else {
+					const speed = totLoaded / (t / 1000.0);
+					if (settings.time_auto) {
+						//decide how much to shorten the test. Every 200ms, the test is shortened by the bonusT calculated here
+						const bonus = (5.0 * speed) / 100000;
+						bonusT += bonus > 400 ? 400 : bonus;
+					}
+					//update status
+					ulStatus = ((speed * 8 * settings.overheadCompensationFactor) / (settings.useMebibits ? 1048576 : 1000000)).toFixed(2); // speed is multiplied by 8 to go from bytes to bits, overhead compensation is applied, then everything is divided by 1048576 or 1000000 to go to megabits/mebibits
+					if ((t + bonusT) / 1000.0 > settings.time_ul_max || failed) {
+						// test is over, stop streams and timer
+						if (failed || isNaN(ulStatus)) ulStatus = "Fail";
+						clearRequests();
+						clearInterval(interval);
+						ulProgress = 1;
+						tlog("ulTest: " + ulStatus + ", took " + (new Date().getTime() - startT) + "ms");
+						done();
+					}
+				}
+			}.bind(this),
+			200
+		);
+	}.bind(this);
+	if (settings.mpot) {
+		tverb("Sending POST request before performing upload test");
+		xhr = [];
+		xhr[0] = new XMLHttpRequest();
+		xhr[0].onload = xhr[0].onerror = function() {
+			tverb("POST request sent, starting upload test");
+			testFunction();
+		}.bind(this);
+		xhr[0].open("POST", settings.url_ul);
+		xhr[0].send();
+	} else testFunction();
+}
+// ping+jitter test, function done is called when it's over
+let ptCalled = false; // used to prevent multiple accidental calls to pingTest
+function pingTest(done) {
+	tverb("pingTest");
+	if (ptCalled) return;
+	else ptCalled = true; // pingTest already called?
+	const startT = new Date().getTime(); //when the test was started
+	let prevT = null; // last time a pong was received
+	let ping = 0.0; // current ping value
+	let jitter = 0.0; // current jitter value
+	let i = 0; // counter of pongs received
+	let prevInstspd = 0; // last ping time, used for jitter calculation
+	xhr = [];
+	// ping function
+	const doPing = function() {
+		tverb("ping");
+		pingProgress = i / settings.count_ping;
+		prevT = new Date().getTime();
+		xhr[0] = new XMLHttpRequest();
+		xhr[0].onload = function() {
+			// pong
+			tverb("pong");
+			if (i === 0) {
+				prevT = new Date().getTime(); // first pong
+			} else {
+				let instspd = new Date().getTime() - prevT;
+				if (settings.ping_allowPerformanceApi) {
+					try {
+						//try to get accurate performance timing using performance api
+						let p = performance.getEntries();
+						p = p[p.length - 1];
+						let d = p.responseStart - p.requestStart;
+						if (d <= 0) d = p.duration;
+						if (d > 0 && d < instspd) instspd = d;
+					} catch (e) {
+						//if not possible, keep the estimate
+						tverb("Performance API not supported, using estimate");
+					}
+				}
+				//noticed that some browsers randomly have 0ms ping
+				if (instspd < 1) instspd = prevInstspd;
+				if (instspd < 1) instspd = 1;
+				const instjitter = Math.abs(instspd - prevInstspd);
+				if (i === 1) ping = instspd;
+				/* first ping, can't tell jitter yet*/ else {
+					if (instspd < ping) ping = instspd; // update ping, if the instant ping is lower
+					if (i === 2) jitter = instjitter;
+					//discard the first jitter measurement because it might be much higher than it should be
+					else jitter = instjitter > jitter ? jitter * 0.3 + instjitter * 0.7 : jitter * 0.8 + instjitter * 0.2; // update jitter, weighted average. spikes in ping values are given more weight.
+				}
+				prevInstspd = instspd;
+			}
+			pingStatus = ping.toFixed(2);
+			jitterStatus = jitter.toFixed(2);
+			i++;
+			tverb("ping: " + pingStatus + " jitter: " + jitterStatus);
+			if (i < settings.count_ping) doPing();
+			else {
+				// more pings to do?
+				pingProgress = 1;
+				tlog("ping: " + pingStatus + " jitter: " + jitterStatus + ", took " + (new Date().getTime() - startT) + "ms");
+				done();
+			}
+		}.bind(this);
+		xhr[0].onerror = function() {
+			// a ping failed, cancel test
+			tverb("ping failed");
+			if (settings.xhr_ignoreErrors === 0) {
+				//abort
+				pingStatus = "Fail";
+				jitterStatus = "Fail";
+				clearRequests();
+				tlog("ping test failed, took " + (new Date().getTime() - startT) + "ms");
+				pingProgress = 1;
+				done();
+			}
+			if (settings.xhr_ignoreErrors === 1) doPing(); //retry ping
+			if (settings.xhr_ignoreErrors === 2) {
+				//ignore failed ping
+				i++;
+				if (i < settings.count_ping) doPing();
+				else {
+					// more pings to do?
+					pingProgress = 1;
+					tlog("ping: " + pingStatus + " jitter: " + jitterStatus + ", took " + (new Date().getTime() - startT) + "ms");
+					done();
+				}
+			}
+		}.bind(this);
+		// send xhr
+		xhr[0].open("GET", settings.url_ping + url_sep(settings.url_ping) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true); // random string to prevent caching
+		xhr[0].send();
+	}.bind(this);
+	doPing(); // start first ping
+}
+// telemetry
+function sendTelemetry(done) {
+	if (settings.telemetry_level < 1) return;
+	xhr = new XMLHttpRequest();
+	xhr.onload = function() {
+		try {
+			const parts = xhr.responseText.split(" ");
+			if (parts[0] == "id") {
+				try {
+					let id = parts[1];
+					done(id);
+				} catch (e) {
+					done(null);
+				}
+			} else done(null);
+		} catch (e) {
+			done(null);
+		}
+	};
+	xhr.onerror = function() {
+		console.log("TELEMETRY ERROR " + xhr.status);
+		done(null);
+	};
+	xhr.open("POST", settings.url_telemetry + url_sep(settings.url_telemetry) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true);
+	const telemetryIspInfo = {
+		processedString: clientIp,
+		rawIspInfo: typeof ispInfo === "object" ? ispInfo : ""
+	};
+	try {
+		const fd = new FormData();
+		fd.append("ispinfo", JSON.stringify(telemetryIspInfo));
+		fd.append("dl", dlStatus);
+		fd.append("ul", ulStatus);
+		fd.append("ping", pingStatus);
+		fd.append("jitter", jitterStatus);
+		fd.append("log", settings.telemetry_level > 1 ? log : "");
+		fd.append("extra", settings.telemetry_extra);
+		xhr.send(fd);
+	} catch (ex) {
+		const postData = "extra=" + encodeURIComponent(settings.telemetry_extra) + "&ispinfo=" + encodeURIComponent(JSON.stringify(telemetryIspInfo)) + "&dl=" + encodeURIComponent(dlStatus) + "&ul=" + encodeURIComponent(ulStatus) + "&ping=" + encodeURIComponent(pingStatus) + "&jitter=" + encodeURIComponent(jitterStatus) + "&log=" + encodeURIComponent(settings.telemetry_level > 1 ? log : "");
+		xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+		xhr.send(postData);
+	}
+}


### PR DESCRIPTION
Este commit introduz uma nova seção para teste de velocidade da internet na aplicação.

Funcionalidades adicionadas:
- Integração da biblioteca LibreSpeed (v5.2.4) para medição de velocidade.
- Nova seção no index.html com interface para:
    - Inserção da velocidade contratada por você (em Mbps).
    - Botão para iniciar o teste.
    - Exibição dos resultados de Ping, Jitter, Download e Upload.
    - Cálculo e exibição da porcentagem da velocidade de download alcançada em relação à contratada.
- Lógica em js/main.js para controlar a interface, inicializar e gerenciar o teste de velocidade, e exibir os resultados.
- Os arquivos da biblioteca LibreSpeed (speedtest.js, e arquivos estáticos para teste) foram adicionados ao diretório lib/librespeed/.
- A interface do usuário foi estilizada com Tailwind CSS para manter a consistência visual.

A funcionalidade foi desenvolvida para ser compatível com ambientes de hospedagem de sites estáticos como o GitHub Pages.